### PR TITLE
Use PATH instead of dotsource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ COPY ./sftp-exporter /usr/local/bin/
 EXPOSE 8080
 RUN useradd -ms /bin/bash sftp-exporter
 USER sftp-exporter
-ENTRYPOINT ["./sftp-exporter"]
+ENTRYPOINT ["sftp-exporter"]


### PR DESCRIPTION
The latest image in Docker Hub is unable to start.

The binary seems to get copied to be used via PATH, but the Entrypoint still uses dotsourcing in the local folder

unable to start container process: exec: "./sftp-exporter": stat ./sftp-exporter: no such file or directory