### PR TITLE
Add timeout to SFTPClient

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,6 +65,7 @@ func init() {
 	rootCmd.Flags().String(viperkeys.SFTPKeyPassphrase, "", "SFTP key passphrase")
 	rootCmd.Flags().Bool(viperkeys.SFTPStatVfs, true, "Use StatVFS extension features")
 	rootCmd.Flags().StringSlice(viperkeys.SFTPPaths, []string{"/"}, "SFTP paths")
+	rootCmd.Flags().String(viperkeys.SFTPTimeout, "10s", "SFTP connection timeout")
 
 	err := viper.BindPFlags(rootCmd.Flags())
 	if err != nil {

--- a/pkg/client/ssh.go
+++ b/pkg/client/ssh.go
@@ -84,6 +84,7 @@ func NewSSHClient() (*ssh.Client, error) {
 		User:            viper.GetString(viperkeys.SFTPUser),
 		Auth:            auth,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         viper.GetDuration(viperkeys.SFTPTimeout),
 	}
 	return ssh.Dial("tcp", addr, clientConfig)
 }

--- a/pkg/constants/viperkeys/viper_keys.go
+++ b/pkg/constants/viperkeys/viper_keys.go
@@ -13,4 +13,5 @@ const (
 	SFTPKeyPassphrase = "sftp-key-passphrase"
 	SFTPStatVfs       = "sftp-statvfs"
 	SFTPPaths         = "sftp-paths"
+	SFTPTimeout       = "sftp-timeout"
 )

--- a/sftp-exporter.yaml
+++ b/sftp-exporter.yaml
@@ -3,4 +3,5 @@ sftp-port: 22
 sftp-user: username
 sftp-password: password
 sftp-paths: ["/path1", "/path2"]
+sftp-timeout: 20s
 log-level: info


### PR DESCRIPTION
If the SFTP server is blocked by a firewall or connecting takes too long, `/metrics` will not generate any response and prometheus will flag this as a service down.